### PR TITLE
feat: tweaks in Pando and dag executables usage information

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -16,15 +16,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"os"
+	"time"
+
 	dssync "github.com/ipfs/go-datastore/sync"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/urfave/cli/v2"
-	"math"
-	"os"
-	"time"
 )
 
 var log = logging.Logger("pando")
@@ -38,7 +39,7 @@ var (
 
 var DaemonCmd = &cli.Command{
 	Name:   "daemon",
-	Usage:  "start a pando daemon, accepting http requests",
+	Usage:  "Start the Pando daemon process",
 	Flags:  nil,
 	Action: daemonCommand,
 }
@@ -98,8 +99,8 @@ func daemonCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("multiaddr is: %s", p2pHost.Addrs())
-	log.Debugf("peerID is: %s", p2pHost.ID())
+	log.Debugf("Pando multiaddr: %s", p2pHost.Addrs())
+	log.Debugf("Pando peer ID: %s", p2pHost.ID())
 
 	if err != nil {
 		return err
@@ -225,7 +226,7 @@ func daemonCommand(cctx *cli.Context) error {
 
 	cancel()
 
-	log.Info("pando stopped")
+	log.Info("Pando daemon process stopped")
 
 	return finalErr
 }

--- a/command/flags.go
+++ b/command/flags.go
@@ -28,7 +28,7 @@ var initFlags = []cli.Flag{
 
 var pandoHostFlag = altsrc.NewStringFlag(&cli.StringFlag{
 	Name:     "pando",
-	Usage:    "Host or host:port of pando to use",
+	Usage:    "Pando service address, which accepts hostname or hostname:port",
 	EnvVars:  []string{"PANDO"},
 	Required: false,
 	Value:    "localhost",
@@ -42,24 +42,24 @@ var registerFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:     "privkey",
-		Usage:    "private key string, used for sign the register request",
+		Usage:    "Provider private key, used for signing the register request",
 		Required: false,
 	},
 	&cli.StringFlag{
 		Name:     "peerid",
-		Usage:    "peerid, used for register",
+		Usage:    "Provider peer ID",
 		Required: false,
 	},
 	pandoHostFlag,
 	&cli.StringSliceFlag{
 		Name:     "provider-addr",
-		Usage:    "Provider address as multiaddr string, example: \"/ip4/127.0.0.1/tcp/3102\"",
+		Usage:    "Provider multiaddr, example: \"/ip4/127.0.0.1/tcp/3102\"",
 		Aliases:  []string{"pa"},
 		Required: true,
 	},
 	&cli.StringFlag{
 		Name:     "miner",
-		Usage:    "miner account",
+		Usage:    "Provider miner account (optional)",
 		Required: false,
 	},
 }

--- a/command/init.go
+++ b/command/init.go
@@ -12,7 +12,7 @@ import (
 
 var InitCmd = &cli.Command{
 	Name:   "init",
-	Usage:  "Initialize indexer node config file and identity",
+	Usage:  "Initialize Pando configuration file and identity",
 	Flags:  initFlags,
 	Action: initCommand,
 }

--- a/command/register.go
+++ b/command/register.go
@@ -5,16 +5,17 @@ import (
 	"Pando/config"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var RegisterCmd = &cli.Command{
 	Name:   "register",
-	Usage:  "Register provider information with an indexer that trusts the provider",
+	Usage:  "Register a metadata provider to a trusted Pando service",
 	Flags:  registerFlags,
 	Action: registerCommand,
 }

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ func main() {
 	}()
 
 	app := &cli.App{
-		Name:    "pando",
-		Usage:   "Pando: Filecoin's metadata server",
+		Name:    "Pando",
+		Usage:   "Sidechain Metadata Service",
 		Version: version.String(),
 		Commands: []*cli.Command{
 			command.DaemonCmd,

--- a/metadata/backup.go
+++ b/metadata/backup.go
@@ -55,7 +55,7 @@ func NewBackupSys(backupCfg *config.Backup) (*backupSystem, error) {
 	if backupCfg == nil || backupCfg.ApiKey == "" {
 		apiKeyEnv, exist := os.LookupEnv(EstuaryApiKeyEnv)
 		if !exist {
-			return nil, fmt.Errorf("please set apikey in $%s", EstuaryApiKeyEnv)
+			return nil, fmt.Errorf("please set apikey in environment variable $%s", EstuaryApiKeyEnv)
 		}
 		apiKey = apiKeyEnv
 	} else {

--- a/mock_provider/dag/dag_provider.go
+++ b/mock_provider/dag/dag_provider.go
@@ -5,6 +5,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/ipfs/go-blockservice"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -14,11 +20,6 @@ import (
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"log"
-	"math/rand"
-	"os"
-	"strconv"
-	"time"
 
 	golegs "github.com/filecoin-project/go-legs"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -53,14 +54,22 @@ func getDagNodes(n int) [][]format.Node {
 // eg: CAESQHWlReUYxW7FDvTAAqG+kNH2U7khW+iv0r+070+zKmFn9t80v5e30/NsBx5XzBLCE4uH/h3d3tpXlwCuO4YGN+w= 1 12D3KooWC3jxxw4TdQtoZDv3QNwmh9rtuiyVL8CADpnJYKHh9AiA /ip4/52.14.211.248/tcp/9000 30
 func main() {
 	if len(os.Args) < 5 {
-		fmt.Println("please input:\r\n1. provider private key\n2. mock dag number\n3. Pando PeerID\n4. Pando MultiAddr\n5. Time wait for data transferring[optional, int]")
+		fmt.Println("Usage:")
+		fmt.Println("    dag [privkey] [countdag] [peerid] [multiaddr] [wait]")
+		fmt.Println()
+		fmt.Println("Arguments:")
+		fmt.Println("    privkey:   provider private key")
+		fmt.Println("    countdag:  count of dag to send")
+		fmt.Println("    peerid:    pando peer id")
+		fmt.Println("    multiaddr: pando multiaddr")
+		fmt.Println("    wait:      seconds of waiting time for data transfer (optional)")
 		os.Exit(1)
 	}
 
 	privstr := os.Args[1]
 	dagnum, err := strconv.Atoi(os.Args[2])
 	if err != nil {
-		log.Fatal("dag number must be integer, not: ", os.Args[2])
+		log.Fatal("The count of dag must be integer, not: ", os.Args[2])
 	}
 	PandoPeerID := os.Args[3]
 	PandoAddrStr := os.Args[4]


### PR DESCRIPTION
# Pando
```
wyang14@C02ZL17GLVDV:/Users/wyang14/project.2021/filecoin/pando/ - (main) > ./Pando         
NAME:
   Pando - Sidechain Metadata Service

USAGE:
   Pando [global options] command [command options] [arguments...]

VERSION:
   v0.0.0+unknown

COMMANDS:
   daemon    Start the Pando daemon process
   init      Initialize Pando configuration file and identity
   register  Register a metadata provider to a trusted Pando service
   ingest    Admin commands to manage ingestion config of indexer
   help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help (default: false)
   --version, -v  print the version (default: false)
```

# dag (Mock Provider)
```
wyang14@C02ZL17GLVDV:/Users/wyang14/project.2021/filecoin/pando/mock_provider/dag/ - (main) > ./dag   
Usage:
    dag [privkey] [countdag] [peerid] [multiaddr] [wait]

Arguments:
    privkey:   provider private key
    countdag:  count of dag to send
    peerid:    pando peer id
    multiaddr: pando multiaddr
    wait:      seconds of waiting time for data transfer (optional)
```